### PR TITLE
Agrega TemplateUtils

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,6 @@
+## [v0.4.0]
+* Agrega Template Utils
+
 ## [v0.2.0]
 ### TimeUtils
 * Agrega clase TimeUtils con metodos basicos para manejo de fechas

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.github.jokoframework</groupId>
   <artifactId>joko-utils</artifactId>
   <packaging>jar</packaging>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <name>joko-utils</name>
   <url>http://maven.apache.org</url>
 

--- a/src/main/java/io/github/jokoframework/utils/template/TemplateUtils.java
+++ b/src/main/java/io/github/jokoframework/utils/template/TemplateUtils.java
@@ -1,0 +1,60 @@
+package io.github.jokoframework.utils.template;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Clase utilitaria para tomar un mensaje que posee valores entre llaves y
+ * los reemplaza por el valor proporcionado en el mapa.
+ * Created by danicricco on 4/24/18.
+ */
+public class TemplateUtils {
+
+    //expresion regular para valores dentro de curly braces
+    private static final Pattern INTERPOLATION_PATTERN = Pattern.compile("\\{(\\w+)(.*?)\\}");
+
+    /**
+     * Formatea un template con tokens (encerrados entre llaves) a partir de
+     * los valores
+     * en un diccionario
+     *
+     * @param template  texto a ser formateado
+     * @param valuesMap Diccionario con valores a ser reemplazados en el template
+     * @return {@link String}
+     */
+    public static String formatMap(String template, Map<String, Object> valuesMap) {
+        StringBuilder formatter = new StringBuilder(template);
+        List<Object> valueList = new ArrayList<>();
+
+        Matcher matcher = INTERPOLATION_PATTERN.matcher(template);
+
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String rest = matcher.group(2);
+
+            String formatKey = String.format("{%s%s}", key, rest);
+            int index = formatter.indexOf(formatKey);
+
+            if (index != -1) {
+                Object value = null;
+                if (valuesMap != null) {
+                    value = valuesMap.get(key);
+                }
+                if (value != null) {
+                    String formatValue = String.format("{%d%s}", valueList.size(), rest);
+                    formatter.replace(index, index + formatKey.length(), formatValue);
+                    valueList.add(value);
+                } else {
+                    throw new ArrayIndexOutOfBoundsException(String.format("Pattern key %s not found in dictionary", key));
+                }
+            }
+        }
+
+        return MessageFormat.format(formatter.toString(), valueList.toArray());
+    }
+
+}

--- a/src/test/java/io/github/jokoframework/template/TemplateUtilTest.java
+++ b/src/test/java/io/github/jokoframework/template/TemplateUtilTest.java
@@ -1,0 +1,31 @@
+package io.github.jokoframework.template;
+
+import io.github.jokoframework.utils.template.TemplateUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by danicricco on 4/24/18.
+ */
+public class TemplateUtilTest {
+
+    @Test
+    public void testStr() {
+
+        String name = "Daniel";
+        Integer puntos = 400;
+
+        String template = "Hola {name} tu tienes {puntos} puntos acumulados";
+        String expectedValue = "Hola "+name+" tu tienes "+puntos+" puntos acumulados";
+
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("name", name);
+        values.put("puntos", puntos);
+        String value = TemplateUtils.formatMap(template, values);
+        Assert.assertEquals(expectedValue, value);
+
+    }
+}


### PR DESCRIPTION
Agrega la clase TemplateUtils que permite realizar el reemplazo devalores en un template.

Se pueden reemplazar con nombre y pasarlos en un mapa, lo cual resulta conveniente si los datos provienen desde un datasource.

Esto lo usamos en proyectos donde se requiere que los textos sean personalizados por el cliente.  Por ejemplo: "Recibiste una transferencia de {monto} "/

Si el cliente quiere cambiar el string del mensaje, fácilmente puede hacerlo porque el template es un dato, y al utilizar el valor {monto} puede elegir en que porción del string aparece.
