### PR TITLE
Agrega tests complementarios para TemplateUtil

### DIFF
--- a/src/test/java/io/github/jokoframework/template/TemplateUtilTest.java
+++ b/src/test/java/io/github/jokoframework/template/TemplateUtilTest.java
@@ -28,4 +28,34 @@ public class TemplateUtilTest {
         Assert.assertEquals(expectedValue, value);
 
     }
+
+    @Test
+    public void testEscapeCurlyBraces() {
+
+        String pin = "320019";
+
+        String template = "Vea su pin entre llaves al final del mensaje. '{'{pin}'}'";
+        String expectedValue = "Vea su pin entre llaves al final del mensaje. {" + pin + "}";
+
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("pin", pin);
+        String value = TemplateUtils.formatMap(template, values);
+        Assert.assertEquals(expectedValue, value);
+
+    }
+
+    @Test
+    public void testFormatType() {
+
+        Integer n = 21;
+
+        String template = "Nació hace {n,number} años";
+        String expectedValue = "Nació hace " + n + " años";
+
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("n", n);
+        String value = TemplateUtils.formatMap(template, values);
+        Assert.assertEquals(expectedValue, value);
+
+    }
 }


### PR DESCRIPTION
La intención es clarificar un poco más el propósito de la clase, ya que
los patrones a interpretarse tienen que ser iguales a la clase
MessageFormat [0], con la ventaja de que los elementos del template
pueden tener un nombre en vez de una posición ordinal.

[0] https://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html

Signed-off-by: Eliseo Ocampos <roskoff@gmail.com>