### PR TITLE
Update to spring 6 and update vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.jokoframework</groupId>
     <artifactId>joko-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.6.6</version>
+    <version>0.6.7</version>
     <name>joko-utils</name>
     <url>http://maven.apache.org</url>
 
@@ -21,14 +21,13 @@
         <orika-core.version>1.5.4</orika-core.version>
         <dependency-check.version>7.1.0</dependency-check.version>
         <junit.version>4.13.1</junit.version>
-        <spring-beans.version>5.3.22</spring-beans.version>
+        <spring-beans.version>6.0.0</spring-beans.version>
         <commons-codec.version>1.15</commons-codec.version>
         <boxable.version>1.6</boxable.version>
         <poi-ooxml.version>4.1.2</poi-ooxml.version>
         <opencsv.version>5.2</opencsv.version>
-        <spring-security-crypto.version>5.7.2</spring-security-crypto.version>
+        <spring-security-crypto.version>6.0.0</spring-security-crypto.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>
-        <slf4j-simple.version>1.7.30</slf4j-simple.version>
         <guava.version>30.0-jre</guava.version>
         <jaxb-api.version>2.4.0-b180830.0359</jaxb-api.version>
         <javax.xml.bind.version>2.4.0-b180830.0359</javax.xml.bind.version>
@@ -129,13 +128,6 @@
             <version>${slf4j-api.version}</version>
         </dependency>
 		
-		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>${slf4j-simple.version}</version>
-		</dependency>
-
         <!-- Mapear DTO a Entities, y vice-versa -->
         <dependency>
             <groupId>ma.glasnost.orika</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <boxable.version>1.6</boxable.version>
         <poi-ooxml.version>5.2.3</poi-ooxml.version>
-        <opencsv.version>5.2</opencsv.version>
+        <opencsv.version>5.7.1</opencsv.version>
         <spring-security-crypto.version>6.0.0</spring-security-crypto.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <guava.version>30.0-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <spring-beans.version>6.0.0</spring-beans.version>
         <commons-codec.version>1.15</commons-codec.version>
         <boxable.version>1.6</boxable.version>
-        <poi-ooxml.version>4.1.2</poi-ooxml.version>
+        <poi-ooxml.version>5.2.3</poi-ooxml.version>
         <opencsv.version>5.2</opencsv.version>
         <spring-security-crypto.version>6.0.0</spring-security-crypto.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>


### PR DESCRIPTION
- feat: Update to spring 6
- feat: Update apache poi to 5.2.3
- feat: Update opencsv to resolve CVE-2022-42889

This pr also removes the dependency on `slf4j-simple`, which should be optional because it causes conflicts with other implementations.